### PR TITLE
Target .default-decoration, scoped to .csd

### DIFF
--- a/src/gtk-3.0/3.20/gtk-compact.css
+++ b/src/gtk-3.0/3.20/gtk-compact.css
@@ -5722,6 +5722,25 @@ row.activatable > grid.horizontal > stack, .view > grid.horizontal > stack, tree
 /************
  * Swatches *
  ************/
+/*************
+ * Titlebars *
+ *************/
+.csd .default-decoration {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.csd .default-decoration button {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.csd .default-decoration .title {
+  min-height: 24px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
 /* GTK NAMED COLORS
    ----------------
    use responsibly! */

--- a/src/gtk-3.0/3.20/gtk-dark-compact.css
+++ b/src/gtk-3.0/3.20/gtk-dark-compact.css
@@ -5722,6 +5722,25 @@ row.activatable > grid.horizontal > stack, .view > grid.horizontal > stack, tree
 /************
  * Swatches *
  ************/
+/*************
+ * Titlebars *
+ *************/
+.csd .default-decoration {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.csd .default-decoration button {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.csd .default-decoration .title {
+  min-height: 24px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
 /* GTK NAMED COLORS
    ----------------
    use responsibly! */

--- a/src/gtk-3.0/3.20/gtk-dark.css
+++ b/src/gtk-3.0/3.20/gtk-dark.css
@@ -5722,6 +5722,25 @@ row.activatable > grid.horizontal > stack, .view > grid.horizontal > stack, tree
 /************
  * Swatches *
  ************/
+/*************
+ * Titlebars *
+ *************/
+.csd .default-decoration {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.csd .default-decoration button {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.csd .default-decoration .title {
+  min-height: 24px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
 /* GTK NAMED COLORS
    ----------------
    use responsibly! */

--- a/src/gtk-3.0/3.20/gtk-light-compact.css
+++ b/src/gtk-3.0/3.20/gtk-light-compact.css
@@ -5722,6 +5722,25 @@ row.activatable > grid.horizontal > stack, .view > grid.horizontal > stack, tree
 /************
  * Swatches *
  ************/
+/*************
+ * Titlebars *
+ *************/
+.csd .default-decoration {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.csd .default-decoration button {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.csd .default-decoration .title {
+  min-height: 24px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
 /* GTK NAMED COLORS
    ----------------
    use responsibly! */

--- a/src/gtk-3.0/3.20/gtk-light.css
+++ b/src/gtk-3.0/3.20/gtk-light.css
@@ -5722,6 +5722,25 @@ row.activatable > grid.horizontal > stack, .view > grid.horizontal > stack, tree
 /************
  * Swatches *
  ************/
+/*************
+ * Titlebars *
+ *************/
+.csd .default-decoration {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.csd .default-decoration button {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.csd .default-decoration .title {
+  min-height: 24px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
 /* GTK NAMED COLORS
    ----------------
    use responsibly! */

--- a/src/gtk-3.0/3.20/gtk.css
+++ b/src/gtk-3.0/3.20/gtk.css
@@ -5722,6 +5722,25 @@ row.activatable > grid.horizontal > stack, .view > grid.horizontal > stack, tree
 /************
  * Swatches *
  ************/
+/*************
+ * Titlebars *
+ *************/
+.csd .default-decoration {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.csd .default-decoration button {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.csd .default-decoration .title {
+  min-height: 24px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
 /* GTK NAMED COLORS
    ----------------
    use responsibly! */

--- a/src/gtk-3.0/3.22/gtk-compact.css
+++ b/src/gtk-3.0/3.22/gtk-compact.css
@@ -5907,6 +5907,25 @@ row.activatable > grid.horizontal > stack, .view > grid.horizontal > stack, tree
 /************
  * Swatches *
  ************/
+/*************
+ * Titlebars *
+ *************/
+.csd .default-decoration {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.csd .default-decoration button {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.csd .default-decoration .title {
+  min-height: 24px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
 /* GTK NAMED COLORS
    ----------------
    use responsibly! */

--- a/src/gtk-3.0/3.22/gtk-dark-compact.css
+++ b/src/gtk-3.0/3.22/gtk-dark-compact.css
@@ -5907,6 +5907,25 @@ row.activatable > grid.horizontal > stack, .view > grid.horizontal > stack, tree
 /************
  * Swatches *
  ************/
+/*************
+ * Titlebars *
+ *************/
+.csd .default-decoration {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.csd .default-decoration button {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.csd .default-decoration .title {
+  min-height: 24px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
 /* GTK NAMED COLORS
    ----------------
    use responsibly! */

--- a/src/gtk-3.0/3.22/gtk-dark.css
+++ b/src/gtk-3.0/3.22/gtk-dark.css
@@ -5907,6 +5907,25 @@ row.activatable > grid.horizontal > stack, .view > grid.horizontal > stack, tree
 /************
  * Swatches *
  ************/
+/*************
+ * Titlebars *
+ *************/
+.csd .default-decoration {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.csd .default-decoration button {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.csd .default-decoration .title {
+  min-height: 24px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
 /* GTK NAMED COLORS
    ----------------
    use responsibly! */

--- a/src/gtk-3.0/3.22/gtk-light-compact.css
+++ b/src/gtk-3.0/3.22/gtk-light-compact.css
@@ -5907,6 +5907,25 @@ row.activatable > grid.horizontal > stack, .view > grid.horizontal > stack, tree
 /************
  * Swatches *
  ************/
+/*************
+ * Titlebars *
+ *************/
+.csd .default-decoration {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.csd .default-decoration button {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.csd .default-decoration .title {
+  min-height: 24px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
 /* GTK NAMED COLORS
    ----------------
    use responsibly! */

--- a/src/gtk-3.0/3.22/gtk-light.css
+++ b/src/gtk-3.0/3.22/gtk-light.css
@@ -5907,6 +5907,25 @@ row.activatable > grid.horizontal > stack, .view > grid.horizontal > stack, tree
 /************
  * Swatches *
  ************/
+/*************
+ * Titlebars *
+ *************/
+.csd .default-decoration {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.csd .default-decoration button {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.csd .default-decoration .title {
+  min-height: 24px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
 /* GTK NAMED COLORS
    ----------------
    use responsibly! */

--- a/src/gtk-3.0/3.22/gtk.css
+++ b/src/gtk-3.0/3.22/gtk.css
@@ -5907,6 +5907,25 @@ row.activatable > grid.horizontal > stack, .view > grid.horizontal > stack, tree
 /************
  * Swatches *
  ************/
+/*************
+ * Titlebars *
+ *************/
+.csd .default-decoration {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.csd .default-decoration button {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.csd .default-decoration .title {
+  min-height: 24px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
 /* GTK NAMED COLORS
    ----------------
    use responsibly! */

--- a/src/gtk-3.0/3.22/sass/apps/_elementary.scss
+++ b/src/gtk-3.0/3.22/sass/apps/_elementary.scss
@@ -267,3 +267,23 @@ window.csd {
 /************
  * Swatches *
  ************/
+
+/*************
+ * Titlebars *
+ *************/
+
+.csd .default-decoration {
+  padding-top: 0;
+  padding-bottom: 0;
+
+  button {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  .title {
+    min-height: 24px;
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}


### PR DESCRIPTION
Okay, this actually targets the right thing. Tested across multiple apps. Doesn't appear to affect anything but elementary Terminal (and theoretically other apps that use that convention).