### PR TITLE
Inactive titlebar

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pop-gtk-theme (2.2.2.0) UNRELEASED; urgency=medium
+
+  * Titlebars and header bars can now be inactive
+
+ -- Ian Santopietro <ian@system76.com>  Wed, 18 Oct 2017 11:05:25 -0600
+
 pop-gtk-theme (2.2.1.0) artful; urgency=medium
 
   * Improve look of GNOME Shell App Folders.

--- a/src/gtk-3.0/3.22/sass/_colors.scss
+++ b/src/gtk-3.0/3.22/sass/_colors.scss
@@ -52,12 +52,10 @@ $titlebar_bg_color:          if($titlebar == 'dark',
                                 if($variant == 'light',
                                    $brown_700,
                                    lighten($brown_800, 5%)),
-                                $brown_300);
-$inactive_titlebar_bg_color: if($titlebar == 'dark',
-                                if($variant == 'light',
-                                   $brown_800,
-                                   lighten($brown_900, 5%)),
                                 $brown_400);
+$inactive_titlebar_bg_color: if($titlebar == 'dark',
+                                mix($titlebar_bg_color, $brown_400, 90%),
+                                mix($titlebar_bg_color, $black, 90%));
 $alt_titlebar_bg_color:      if($titlebar == 'dark',
                                 $brown_800,
                                 mix($brown_300, $brown_400, 50%));

--- a/src/gtk-3.0/3.22/sass/_common.scss
+++ b/src/gtk-3.0/3.22/sass/_common.scss
@@ -1042,6 +1042,7 @@ headerbar {
 
   &:backdrop {
     color: $titlebar_secondary_fg_color;
+    background-color: $inactive_titlebar_bg_color;
 
     &:disabled :not(button) > label { color: $titlebar_disabled_secondary_fg_color; }
   }
@@ -1166,7 +1167,11 @@ headerbar {
 
   .tiled &,
   .maximized &,
-  .fullscreen & {
+  .fullscreen &,
+  .tiled-bottom &,
+  .tiled-top &,
+  .tiled-left &,
+  .tiled-right {
     border-radius: 0; // squared corners when the window is maximized, tiled, or fullscreen
     box-shadow: $shadow_1;
   }
@@ -1259,6 +1264,10 @@ headerbar { // headerbar border rounding
   }
 
   @extend %titlebar;
+
+  &:backdrop {
+    background-color: $inactive_titlebar_bg_color;
+  }
 }
 
 

--- a/src/gtk-3.0/3.22/sass/_variables.scss
+++ b/src/gtk-3.0/3.22/sass/_variables.scss
@@ -1,5 +1,5 @@
 /*****************************
- * Pop!_GTK+ Version 2.2.0r0 *
+ * Pop!_GTK+ Version 2.2.2r0 *
  *****************************/
 
 $asset_suffix: if($variant == 'dark', '-dark', '');


### PR DESCRIPTION
This branch adds inactive titlebar styling to the theme, to help distinguish active versus background windows. This is particularly useful when dealing with two half-tiled windows.